### PR TITLE
Fix: Only mount “scroll” listener once

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,8 +20,7 @@ function tick() {
 }
 
 function uos(begin, end, callback) {
-  instances.push([begin, end, callback]);
-  window.addEventListener('scroll', tick, { passive: true });
+  instances.push([begin, end, callback]) > 1 || window.addEventListener('scroll', tick, { passive: true });
 }
 
 export default uos;


### PR DESCRIPTION
Since `Array.push` returns the new length of the array, this uses that value to block additional listeners from being mounted.

---

Closes #1 