### PR TITLE
Feat: Remove observers and listener (optional)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 const observers = [];
 
 function tick() {
-  let i = observers.length, o, r;
-  while (i--) {
-    o = observers[i];
+  let len=observers.length, o, r;
+  while (len--) {
+    o = observers[len];
     r = o[1] <= 1
         ? (pageYOffset / (document.body.scrollHeight - innerHeight) - o[0]) / (o[1] - o[0])
         : (pageYOffset - o[0]) / (o[1] - o[0]);
@@ -11,8 +11,11 @@ function tick() {
   }
 }
 
-function uos(begin, end, callback) {
-  observers.push([begin, end, callback]) > 1 || addEventListener('scroll', tick, { passive: true });
+export default function (begin, end, func, len) {
+	len = observers.push([begin, end, func]);
+	len > 1 || addEventListener('scroll', tick);
+  return function (toRemove) {
+  	observers.splice(len - 1, 1);
+  	if (toRemove) removeEventListener('scroll', tick);
+  }
 }
-
-export default uos;

--- a/src/index.js
+++ b/src/index.js
@@ -12,10 +12,10 @@ function tick() {
 }
 
 export default function (begin, end, func, len) {
-	len = observers.push([begin, end, func]);
-	len > 1 || addEventListener('scroll', tick);
+  len = observers.push([begin, end, func]);
+  len > 1 || addEventListener('scroll', tick);
   return function (toRemove) {
-  	observers.splice(len - 1, 1);
-  	if (toRemove) removeEventListener('scroll', tick);
+    observers.splice(len - 1, 1);
+    if (toRemove) removeEventListener('scroll', tick);
   }
 }


### PR DESCRIPTION
Removes individually instances by calling the returned function directly.

Optionally, you can remove the _entire_ `scroll` event listener if you pass a truthy value into the returned unlistener.

```js
let unlisten;

[ ... ].forEach(arr => {
  unlisten = uos(...arr);
});

// unlisten is now a fn

unlisten(); // splices the last instance
unlisten(true); // tears down everything
```

The module is now 250b – which is the original package size, but now with more features 😁 

---

Closes #2 
